### PR TITLE
Add a feature flags for selectively pulling in which tls the reqwest dependency will use

### DIFF
--- a/xrpl_http_client/Cargo.toml
+++ b/xrpl_http_client/Cargo.toml
@@ -13,10 +13,13 @@ thiserror = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11.15", features = ["json"] }
 sha2 = "0.10"
 libsecp256k1 = "0.7"
 tracing = "0.1"
 xrpl_types = { path = "../xrpl_types", version = "0.15" }
 xrpl_api = { path = "../xrpl_api", version = "0.15" }
 xrpl_binary_codec = { path = "../xrpl_binary_codec", version = "0.15" }
+
+[features]
+reqwest-rustls = ["reqwest/rustls-tls"]

--- a/xrpl_http_client/Cargo.toml
+++ b/xrpl_http_client/Cargo.toml
@@ -13,7 +13,7 @@ thiserror = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.11.15", features = ["json"] }
+reqwest = { version = "0.11.15", features = ["json"], default-features = false }
 sha2 = "0.10"
 libsecp256k1 = "0.7"
 tracing = "0.1"
@@ -23,3 +23,4 @@ xrpl_binary_codec = { path = "../xrpl_binary_codec", version = "0.15" }
 
 [features]
 reqwest-rustls = ["reqwest/rustls-tls"]
+reqwest-default-tls = ["reqwest/default-tls"]


### PR DESCRIPTION
When doing cross compilation with rust. OpenSSL can be quite tricky and projects doing that would like the option of using rustls instead of openssl. This PR allows users of the XRPL Rust SDK to customize which tls dependency gets used with the underlying `reqwest` crate used by the `xrpl_http_client`.