### PR TITLE
feat(xrpl_sdk_jsonrpc): add header of applicatoin json

### DIFF
--- a/xrpl_http_client/src/client.rs
+++ b/xrpl_http_client/src/client.rs
@@ -123,6 +123,7 @@ impl Client {
             .post(&self.base_url)
             .body(body)
             .header(reqwest::header::USER_AGENT, &self.user_agent)
+            .header(reqwest::header::CONTENT_TYPE, "application/json")
             .send()
             .await?;
 


### PR DESCRIPTION
Ripple nodes are often located behind gateways requiring strict HTTP headers(application/json) .