### PR TITLE
Fix version after breaking change

### DIFF
--- a/xrpl_api/Cargo.toml
+++ b/xrpl_api/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "xrpl_api"
 description = "XRPL Protocol endpoints and resouces"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 license = "Apache-2.0"
 repository = "https://github.com/gmosx/xrpl-sdk-rust/tree/main/xrpl_api"


### PR DESCRIPTION
This commit https://github.com/gmosx/xrpl-sdk-rust/commit/a8bbb8d710cf739616754f9d3ac9a482614cfac0 breaks the version so I'm suggesting to update it