### PR TITLE
Fix internal version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,21 @@ members = [
     "xrpl_http_client",
     "xrpl_ws_client",
 ]
+
+[workspace.package]
+version = "0.16.1"
+edition = "2021"
+authors = ["Georgios Moschovitis <george.moschovitis@gmail.com>"]
+
+[workspace.dependencies]
+ascii = "1.1.0"
+assert_matches = "1.5.0"
+enumflags2 = "0.7.7"
+hex = "0.4"
+libsecp256k1 = "0.7.1"
+serde = "1"
+serde_json = "1"
+sha2 = "0.10"
+thiserror = "1"
+tokio = "1"
+tracing = "0.1"

--- a/xrpl_address_codec/Cargo.toml
+++ b/xrpl_address_codec/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "xrpl_address_codec"
 description = "Binary serialization for XRPL Protocol addresses"
-version = "0.16.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 license = "Apache-2.0"
 repository = "https://github.com/gmosx/xrpl-sdk-rust/tree/main/xrpl_address_codec"
 keywords = ["xrpl", "ledger", "api", "protocol"]
-authors = ["Georgios Moschovitis <george.moschovitis@gmail.com>"]
 
 [dependencies]

--- a/xrpl_api/Cargo.toml
+++ b/xrpl_api/Cargo.toml
@@ -12,7 +12,7 @@ authors = ["Georgios Moschovitis <george.moschovitis@gmail.com>"]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 enumflags2 = { version = "0.7.7", features = ["serde"] }
-xrpl_types = { path = "../xrpl_types", version = "0.15" }
+xrpl_types = { path = "../xrpl_types" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/xrpl_api/Cargo.toml
+++ b/xrpl_api/Cargo.toml
@@ -1,18 +1,18 @@
 [package]
 name = "xrpl_api"
 description = "XRPL Protocol endpoints and resouces"
-version = "0.16.0"
-edition = "2021"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 license = "Apache-2.0"
 repository = "https://github.com/gmosx/xrpl-sdk-rust/tree/main/xrpl_api"
 keywords = ["xrpl", "ledger", "api", "protocol"]
-authors = ["Georgios Moschovitis <george.moschovitis@gmail.com>"]
 
 [dependencies]
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-enumflags2 = { version = "0.7.7", features = ["serde"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+enumflags2 = { workspace = true, features = ["serde"] }
 xrpl_types = { path = "../xrpl_types" }
 
 [dev-dependencies]
-assert_matches = "1.5.0"
+assert_matches.workspace = true

--- a/xrpl_binary_codec/Cargo.toml
+++ b/xrpl_binary_codec/Cargo.toml
@@ -1,19 +1,18 @@
 [package]
 name = "xrpl_binary_codec"
 description = "Binary serialization for XRPL Protocol objects"
-version = "0.16.0"
-license = "Apache-2.0"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 repository = "https://github.com/gmosx/xrpl-sdk-rust/tree/main/xrpl_binary_codec"
 keywords = ["xrpl", "ledger", "api", "protocol"]
-authors = ["Georgios Moschovitis <george.moschovitis@gmail.com>"]
-edition = "2021"
 
 [dependencies]
 xrpl_types = { path = "../xrpl_types", default-features = false }
-serde_json = { version = "1", default-features = false, features = ["alloc"] }
-hex = { version = "0.4", default-features = false, features = ["alloc"] }
-sha2 = { version = "0.10.7", default-features = false }
-libsecp256k1 = { version = "0.7.1", default-features = false, features = [
+serde_json = { workspace = true, default-features = false, features = ["alloc"] }
+hex = { workspace = true, default-features = false, features = ["alloc"] }
+sha2 = { workspace = true, default-features = false }
+libsecp256k1 = { workspace = true, default-features = false, features = [
     "static-context",
     "hmac",
 ] }
@@ -32,10 +31,10 @@ std = ["hex/std", "serde_json/std"]
 json = []
 
 [dev-dependencies]
-ascii = "1.1.0"
-assert_matches = "1.5.0"
-enumflags2 = { version = "0.7.7" }
-serde = { version = "1", default-features = false, features = [
+ascii.workspace = true
+assert_matches.workspace = true
+enumflags2.workspace = true
+serde = { workspace = true, default-features = false, features = [
     "derive",
     "alloc",
 ] }

--- a/xrpl_binary_codec/Cargo.toml
+++ b/xrpl_binary_codec/Cargo.toml
@@ -9,7 +9,7 @@ authors = ["Georgios Moschovitis <george.moschovitis@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-xrpl_types = { path = "../xrpl_types", version = "0.15", default-features = false }
+xrpl_types = { path = "../xrpl_types", default-features = false }
 serde_json = { version = "1", default-features = false, features = ["alloc"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 sha2 = { version = "0.10.7", default-features = false }

--- a/xrpl_binary_codec/src/deserializer.rs
+++ b/xrpl_binary_codec/src/deserializer.rs
@@ -154,13 +154,13 @@ impl Deserializer {
         data: &[u8],
     ) -> Result<Value, BinaryCodecError> {
         match type_code {
-            TypeCode::Hash256 => Ok(Value::String(hex::encode_upper(&data))),
+            TypeCode::Hash256 => Ok(Value::String(hex::encode_upper(data))),
             TypeCode::AccountId => {
                 let account_bytes: [u8; 20] =
                     data.try_into().map_err(|_| BinaryCodecError::Overflow)?;
                 Ok(Value::String(AccountId(account_bytes).to_address()))
             }
-            TypeCode::Blob => Ok(Value::String(hex::encode_upper(&data))),
+            TypeCode::Blob => Ok(Value::String(hex::encode_upper(data))),
             TypeCode::Object => {
                 let mut accumulator: HashMap<String, Value> = HashMap::new();
                 self.bytes = Bytes::from(data.to_vec());
@@ -192,7 +192,7 @@ impl Deserializer {
                 }
                 Ok(Value::Array(result))
             }
-            _ => Ok(Value::String(hex::encode_upper(&data))), // TODO: default other types to Blob for now
+            _ => Ok(Value::String(hex::encode_upper(data))), // TODO: default other types to Blob for now
         }
     }
 }

--- a/xrpl_cli/Cargo.toml
+++ b/xrpl_cli/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "xrpl_cli"
 description = "A CLI for the XRP Ledger"
-version = "0.16.0"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 license = "Apache-2.0"
 repository = "https://github.com/gmosx/xrpl-sdk-rust/tree/main/xrpl_http_client"
 keywords = ["xrpl", "ledger", "cli"]
-authors = ["Georgios Moschovitis <george.moschovitis@gmail.com>"]
-edition = "2021"
 
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tracing = "0.1"
+tokio = { workspace = true, features = ["full"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tracing.workspace = true
 tracing-subscriber = "0.3"
-hex = "0.4"
-libsecp256k1 = "0.7.1"
+hex.workspace = true
+libsecp256k1.workspace = true
 prettytable-rs = "0.10"
 rust_decimal = "1.32.0"
 xrpl_binary_codec = { path = "../xrpl_binary_codec" }
@@ -26,7 +26,7 @@ xrpl_api = { path = "../xrpl_api" }
 xrpl_http_client = { path = "../xrpl_http_client" }
 
 [dev-dependencies]
-assert_matches = "1.5.0"
+assert_matches.workspace = true
 
 [[bin]]
 name = "xrpl"

--- a/xrpl_cli/Cargo.toml
+++ b/xrpl_cli/Cargo.toml
@@ -20,10 +20,10 @@ hex = "0.4"
 libsecp256k1 = "0.7.1"
 prettytable-rs = "0.10"
 rust_decimal = "1.32.0"
-xrpl_binary_codec = { path = "../xrpl_binary_codec", version = "0.15" }
-xrpl_types = { path = "../xrpl_types", version = "0.15" }
-xrpl_api = { path = "../xrpl_api", version = "0.15" }
-xrpl_http_client = { path = "../xrpl_http_client", version = "0.15" }
+xrpl_binary_codec = { path = "../xrpl_binary_codec" }
+xrpl_types = { path = "../xrpl_types" }
+xrpl_api = { path = "../xrpl_api" }
+xrpl_http_client = { path = "../xrpl_http_client" }
 
 [dev-dependencies]
 assert_matches = "1.5.0"

--- a/xrpl_http_client/Cargo.toml
+++ b/xrpl_http_client/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
 name = "xrpl_http_client"
 description = "A strongly-typed client for the XRP Ledger JSONRPC API"
-version = "0.16.0"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 license = "Apache-2.0"
 repository = "https://github.com/gmosx/xrpl-sdk-rust/tree/main/xrpl_http_client"
 keywords = ["xrpl", "ledger", "client", "jsonrpc", "api"]
-authors = ["Georgios Moschovitis <george.moschovitis@gmail.com>"]
-edition = "2021"
 
 [dependencies]
-thiserror = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tokio = { version = "1", features = ["full"] }
+thiserror.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
+tokio = { workspace = true, features = ["full"] }
 reqwest = { version = "0.11.15", features = ["json"], default-features = false }
-sha2 = "0.10"
-libsecp256k1 = "0.7"
-tracing = "0.1"
-xrpl_types = { path = "../xrpl_types", version = "0.15" }
-xrpl_api = { path = "../xrpl_api", version = "0.15" }
-xrpl_binary_codec = { path = "../xrpl_binary_codec", version = "0.15" }
+sha2.workspace = true
+libsecp256k1.workspace = true
+tracing.workspace = true
+xrpl_types = { path = "../xrpl_types" }
+xrpl_api = { path = "../xrpl_api" }
+xrpl_binary_codec = { path = "../xrpl_binary_codec" }
 
 [features]
 default = ["std"]

--- a/xrpl_types/Cargo.toml
+++ b/xrpl_types/Cargo.toml
@@ -1,31 +1,30 @@
 [package]
 name = "xrpl_types"
 description = "Core types and related functions for the XRP Ledger"
-version = "0.16.0"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 license = "Apache-2.0"
 repository = "https://github.com/gmosx/xrpl-sdk-rust/tree/main/xrpl_types"
 keywords = ["xrpl", "ledger", "api"]
-authors = ["Georgios Moschovitis <george.moschovitis@gmail.com>"]
-edition = "2021"
 
 [dependencies]
-serde = { version = "1", default-features = false, features = [
+serde = { workspace = true, default-features = false, features = [
     "derive",
     "alloc",
 ] }
-serde_json = { version = "1", default-features = false, features = ["alloc"] }
+serde_json = { workspace = true, default-features = false, features = ["alloc"] }
 bs58 = { version = "0.5.0", default-features = false, features = [
     "alloc",
     "check",
 ] }
-ascii = { version = "1.1.0", default-features = false, features = ["alloc"] }
-hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
-enumflags2 = { version = "0.7.7", default-features = false }
+ascii = { workspace = true, default-features = false, features = ["alloc"] }
+hex = { workspace = true, default-features = false, features = ["alloc"] }
+enumflags2 = { workspace = true, default-features = false }
 
 [features]
 default = ["std"]
 std = ["serde_json/std", "hex/std", "ascii/std"]
 
 [dev-dependencies]
-assert_matches = "1.5.0"
-hex = "0.4.3"
+assert_matches.workspace = true

--- a/xrpl_ws_client/Cargo.toml
+++ b/xrpl_ws_client/Cargo.toml
@@ -1,25 +1,25 @@
 [package]
 name = "xrpl_ws_client"
 description = "A strongly-typed client for the XRP Ledger WebSocket API"
-version = "0.16.0"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
 license = "Apache-2.0"
 repository = "https://github.com/gmosx/xrpl-sdk-rust/tree/main/xrpl_http_client"
 keywords = ["xrpl", "ledger", "client", "websocket", "api"]
-authors = ["Georgios Moschovitis <george.moschovitis@gmail.com>"]
-edition = "2021"
 
 [dependencies]
-thiserror = "1"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+thiserror.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 futures = "0.3"
 futures-util = "0.3"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 tokio-tungstenite = { version = "0.20", features = ["rustls-tls-webpki-roots"] }
 async-stream = "0.3"
-tracing = "0.1"
+tracing.workspace = true
 uuid = { version = "1", features = ["v4", "fast-rng"] }
-xrpl_types = { path = "../xrpl_types", version = "0.15" }
-xrpl_api = { path = "../xrpl_api", version = "0.15" }
-xrpl_binary_codec = { path = "../xrpl_binary_codec", version = "0.15" }
+xrpl_types = { path = "../xrpl_types" }
+xrpl_api = { path = "../xrpl_api" }
+xrpl_binary_codec = { path = "../xrpl_binary_codec" }


### PR DESCRIPTION
- Fixed internal crates reference still pointing to `0.15.0`
- Added workspace dependencies
- Put `version`, `edition`, and `authors` on the workspace and referenced it on the member projects