### PR TITLE
Serde Serialization for TransactionEvent and nested types

### DIFF
--- a/xrpl_api/src/api/with_ledger_spec.rs
+++ b/xrpl_api/src/api/with_ledger_spec.rs
@@ -44,7 +44,7 @@ pub struct RetrieveLedgerSpec {
 }
 
 /// Ledger specification in returned data
-#[derive(Default, Debug, Clone, Deserialize)]
+#[derive(Default, Debug, Clone, Serialize, Deserialize)]
 pub struct ReturnLedgerSpec {
     pub ledger_hash: Option<String>,
     pub ledger_index: Option<u32>,

--- a/xrpl_api/src/events/transaction.rs
+++ b/xrpl_api/src/events/transaction.rs
@@ -1,7 +1,7 @@
 use crate::{Meta, ReturnLedgerSpec, Transaction, TransactionResult};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 pub struct TransactionEvent {
     pub engine_result: TransactionResult,
     pub engine_result_code: i32,

--- a/xrpl_api/src/types/transaction.rs
+++ b/xrpl_api/src/types/transaction.rs
@@ -1,7 +1,7 @@
 mod common;
 mod variants;
 
-use serde::Deserialize;
+use serde::{Serialize, Deserialize};
 
 pub use common::*;
 
@@ -13,7 +13,7 @@ pub use variants::payment::*;
 pub use variants::trust_set::*;
 
 /// Ledger transaction. See <https://xrpl.org/transaction-formats.html>
-#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "TransactionType")]
 pub enum Transaction {
     AccountDelete(AccountDeleteTransaction),


### PR DESCRIPTION
### Description:
This pull request enables serde serialization for the `TransactionEvent` struct and its associated nested types by adding `#[derive(Serialize)]`. This allows users to serialize `TransactionEvent` instances, facilitating tasks such as logging, data storage, and network communication in formats like JSON.

### Changes:
- Added `#[derive(Serialize)]` to the `TransactionEvent` struct.
- Added `#[derive(Serialize)]` to nested types required for serialization:
    - `Transaction`
    - `ReturnLedgerSpec`